### PR TITLE
Auto refresh config sheet and a few adjustments to scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Let's look at another example for the same product:
 * **Original Title**: 2XU Men's Swim Compression Long Sleeve Top
 * **Generated Title**: 2XU Men's Swim Compression Top Size M
 * **Score**: -0.5
-* Reasoning: Key attributes were removed from the title, namely "Long Sleeve",
+* Reasoning: Key information was removed from the title, namely "Long Sleeve",
   which describes the type of the product. FeedGen identifies this information
   by first examining the structure of titles via what we refer to as
   **templates** in our uniquitous language, before diving deeper and comparing
@@ -230,10 +230,10 @@ Let's look at another example for the same product:
     negative score.
 
 > FeedGen is conservative in its scoring; it will assign a score of -0.5
-  whenever *any* attributes or words get removed, even if those words were
-  promotional phrases such as `get yours now` or `while stocks last`, which
-  should not be part of titles as per the [Best Practices](#best-practices)
-  outlined by Merchant Center (MC).
+  whenever *any* words get removed, even if those words were promotional phrases
+  such as `get yours now` or `while stocks last`, which should not be part of
+  titles as per the [Best Practices](#best-practices) outlined by Merchant
+  Center (MC).
 
 Alright, so what makes a good title? Let's look at another example:
 
@@ -258,7 +258,7 @@ Finally, what's the ideal case? Let's take a look at one last example:
 
 So in summary, the scoring systems works as follows:
 
-|Are there hallucinations?|Have we removed key attributes / words?|No change at all?|Have we optimised the title?|Did we fill in missing gaps or create [new attributes](#feed-gaps-and-new-attributes)?|
+|Are there hallucinations?|Have we removed any words?|No change at all?|Have we optimised the title?|Did we fill in missing gaps or extract [new attributes](#feed-gaps-and-new-attributes)?|
 |-|-|-|-|-|
 |-1|-0.5|0|Add 0.5|Add 0.5|
 
@@ -275,7 +275,7 @@ FeedGen does not just fill gaps in your feed, but might also create completely
 **new** attributes that were not provided in the *Input Feed*. This is
 controllable via the few-shot prompting examples in the *Config* sheet; by
 providing "new" attributes that do not exist in the input within those examples,
-FeedGen will attempt to *infer* values for those new attributes from other
+FeedGen will attempt to *extract* values for those new attributes from other
 values in the input feed. Let's take a look at an example:
 
 |Original Title|Product Attributes in Original Title|Product Attributes in Generated Title|Generated Attribute Values|

--- a/dist/index.js
+++ b/dist/index.js
@@ -688,7 +688,7 @@ function optimizeRow(headers, data) {
       ? Status.SUCCESS
       : Status.NON_COMPLIANT;
   const score = status === Status.NON_COMPLIANT ? String(-1) : totalScore;
-  const approval = Number(score) > 0;
+  const approval = Number(score) >= 0;
   return [
     approval,
     status,

--- a/src/app.ts
+++ b/src/app.ts
@@ -424,7 +424,7 @@ function optimizeRow(
       ? Status.SUCCESS
       : Status.NON_COMPLIANT;
   const score = status === Status.NON_COMPLIANT ? String(-1) : totalScore;
-  const approval = Number(score) > 0;
+  const approval = Number(score) >= 0;
 
   return [
     approval,

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,8 @@ export enum Status {
   NON_COMPLIANT = 'Failed compliance checks',
 }
 
+export const EMPTY = 'EMPTY';
+
 export const CONFIG = {
   userSettings: {
     feed: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
-    "lib": ["es2020"],
+    "target": "ES2021",
+    "module": "ES2020",
+    "lib": ["ES2021"],
     "moduleResolution": "node",
     "outDir": "dist",
     "rootDir": ".",


### PR DESCRIPTION
- We now programmatically auto-refresh the config sheet to update any broken formulas (by adding a new row then immediately deleting it) so that users do not have to perform this manually. This was an issue usually only when you copy the sheet for the first time from GitHub.
- Removed "attributes" now don't penalise the score. This was done as removed "words" are more powerful and factual, while removed attributes relies on the accuracy of the language model in deciphering the existing structure of the original title, which it doesn't always get right.
- Empty attribute values (that have a value corresponding to the attribute itself - e.g. a size value of just "Size") are now treated as empty.
- Ensuring via prompt-tuning that the generated "product attribute keys" always have a corresponding value in
"product attribute values".
- Updating TS lib compiler settings to allow 'replaceAll' for strings