### PR TITLE
Added title generation checkbox + title from input in few-shots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .DS_Store
 .clasp*.json
 *.tgz
+.vscode

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,21 +1,13 @@
 {
   "timeZone": "Europe/Berlin",
   "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Sheets",
-        "version": "v4",
-        "serviceId": "sheets"
-      }
-    ]
+    "enabledAdvancedServices": [{
+      "userSymbol": "Sheets",
+      "serviceId": "sheets",
+      "version": "v4"
+    }]
   },
   "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "V8",
-  "oauthScopes": [
-    "https://www.googleapis.com/auth/script.external_request",
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/script.scriptapp",
-    "https://www.googleapis.com/auth/script.container.ui"
-  ]
+  "oauthScopes": ["https://www.googleapis.com/auth/script.external_request", "https://www.googleapis.com/auth/spreadsheets", "https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/script.scriptapp", "https://www.googleapis.com/auth/script.container.ui"],
+  "runtimeVersion": "V8"
 }

--- a/dist/appsscript.json
+++ b/dist/appsscript.json
@@ -1,21 +1,13 @@
 {
   "timeZone": "Europe/Berlin",
   "dependencies": {
-    "enabledAdvancedServices": [
-      {
-        "userSymbol": "Sheets",
-        "version": "v4",
-        "serviceId": "sheets"
-      }
-    ]
+    "enabledAdvancedServices": [{
+      "userSymbol": "Sheets",
+      "serviceId": "sheets",
+      "version": "v4"
+    }]
   },
   "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "V8",
-  "oauthScopes": [
-    "https://www.googleapis.com/auth/script.external_request",
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/script.scriptapp",
-    "https://www.googleapis.com/auth/script.container.ui"
-  ]
+  "oauthScopes": ["https://www.googleapis.com/auth/script.external_request", "https://www.googleapis.com/auth/spreadsheets", "https://www.googleapis.com/auth/cloud-platform", "https://www.googleapis.com/auth/script.scriptapp", "https://www.googleapis.com/auth/script.container.ui"],
+  "runtimeVersion": "V8"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,9 +35,13 @@ export const CONFIG = {
         row: 2,
         col: 4,
       },
-      generateDescriptions: {
+      generateTitles: {
         row: 2,
         col: 5,
+      },
+      generateDescriptions: {
+        row: 2,
+        col: 6,
       },
     },
     vertexAi: {


### PR DESCRIPTION
Use case: Generate only descriptions, leave titles as is.
Will auto-approve all since we don't score descriptions.

Bonus: extracting title from few-shot examples to streamline manual attribute annotation in go/feedgen-dev
