### PR TITLE
Update index.html DOM text reinterpreted as HTML

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -155,7 +155,7 @@ limitations under the License.
           'for detailed information.<br/>Errors:';
       }
 
-      errorElem.innerHTML = errorMessage;
+      errorElem.innerText = errorMessage;
     }
 
     function log(message) {


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.